### PR TITLE
added focus on primary button, if there is no input

### DIFF
--- a/angular-prompt.js
+++ b/angular-prompt.js
@@ -93,6 +93,16 @@ angular.module('cgPrompt').controller('cgPromptCtrl',['$scope','options','$timeo
             if (elem.focus) {
                 elem.focus();
             }
+        } else {
+            var primaryBtn = document.querySelector('.btn-primary');
+            if (primaryBtn) {
+                if (primaryBtn.select) {
+                    primaryBtn.select();
+                }
+                if (primaryBtn.focus) {
+                    primaryBtn.focus();
+                }
+            }
         }
     },100);
     


### PR DESCRIPTION
If option 'input' was set to false, there were no focused element. This pull request adds focus on primary button (if exist and input==false).